### PR TITLE
major refactoring of pipeline

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -12,17 +12,17 @@ process {
   }
   withName: filterGenotypes {
     cpus = { 1 * task.attempt }
-  	memory = { 64.GB * task.attempt }
+  	memory = { 32.GB * task.attempt }
   	time = { 1.h * task.attempt }
   }
    withName: runGWAS {
-   cpus = { 1 * task.attempt }
+   cpus = { 2 * task.attempt }
    memory = { 32.GB * task.attempt }
-   time = { 2.h * task.attempt }
+   time = { 8.h * task.attempt }
   }
   withName: plotGWAS {
     cpus = { 1 * task.attempt }
-  	memory = { 2.GB * task.attempt }
+  	memory = { 4.GB * task.attempt }
   	time = { 1.h * task.attempt }
   }
   errorStrategy = { ( task.exitStatus == 143 || task.exitStatus == 137 ) ? 'retry' : 'finish' }

--- a/conf/cbe.config
+++ b/conf/cbe.config
@@ -3,12 +3,17 @@
  * -------------------------------------------------
  */
 
-singularity.enabled = true
+params.genotype  = "/scratch-cbe/shared/genotypes_for_pygwas/1.0.0/1001genomes/all_chromosomes_binary.hdf5"
+
+singularity {
+  enabled = true
+  cacheDir = '/resources/containers'
+}
 
 process {
   container = 'docker.artifactory.imp.ac.at/becker/gwas-nf:dev'
   executor = 'slurm'
-  module = 'singularity/3.2.1'
+  module = 'singularity/3.4.1'
   queue = { task.memory <= 170.GB ? 'c' : 'm' }
   clusterOptions = { task.time <= 8.h ? '--qos short': task.time <= 48.h ? '--qos medium' : '--qos long' }
 }

--- a/lib/ParameterChecks.groovy
+++ b/lib/ParameterChecks.groovy
@@ -1,0 +1,8 @@
+class ParameterChecks {
+  static void checkParams(params) {
+    assert params.phenotype, "ERROR! A phenotype table has to be provided!"
+    assert ['no_transformation', 'mean_standardize', 'quantile_gaussianize', 'boxcox'].contains(params.transform), "ERROR! Phenotype transformation has to be either no_transformation, mean_standardize, quantile_gaussianize or boxcox"
+    assert params.genotype.contains('hdf5'), 'ERROR! SNP matrix in hdf5 format has to be provided'
+    assert params.mac instanceof Integer, 'ERROR! Minor allele count threshold has to be an Integer'
+    }
+}

--- a/main.nf
+++ b/main.nf
@@ -12,6 +12,9 @@
 ----------------------------------------------------------------------------------------
 */
 
+// validate parameters
+ParameterChecks.checkParams(params)
+
 Channel
     .fromFilePairs(params.phenotype, checkIfExists: true, size: 1)
     .set {ch_pheno}
@@ -20,135 +23,174 @@ Channel
     .fromPath(params.genotype, checkIfExists: true)
     .set {ch_geno}
 
-Channel
-    .fromPath(params.kinship, checkIfExists: true)
-    .set {ch_kinship}
-
 process scatterPhenotypes {
+    tag "$env"
+
+    echo true
     publishDir "${params.outdir}/traits", mode: 'copy'
     input:
-        tuple val(env), file(pheno) from ch_pheno
+        tuple val(env), path(pheno) from ch_pheno
 
     output:
-        tuple val(env), file('*.csv') into traits mode flatten
+        tuple val(env), path('*.csv') into traits mode flatten optional true
 
     script:
+        def selection = params.trait ? "['${params.trait.tokenize(',').join("','")}']" : "phenotype.columns"
         """
         #!/usr/bin/env python
 
         import pandas as pd
-        
+
         phenotype = pd.read_csv("${pheno}", index_col=[0])
-        for index, trait in enumerate(phenotype.columns):
-            chunk = phenotype.iloc[:,[index]].dropna()
-            chunk.to_csv("{}.csv".format(trait))
+        for trait in ${selection}: 
+            try:
+                slice = phenotype[trait].dropna()
+                slice.to_csv(f'{trait}.csv')
+            except KeyError:
+                print(f'Trait {trait} not found in ${pheno.name}. Skipping.')
         """
 }
 
 traits
  .map { env, file -> [ env, file.baseName, file] }
- .groupTuple(by: 1)
+ .groupTuple(by: params.multitrait ? 1 : 2, size: params.multitrait ? 0 : 1)
  .set {ch_traitsplit}
 
 process filterGenotypes {
-    publishDir "${params.outdir}/genotypes", mode: 'copy'
+    tag "$traitname"
+
     input:
         file geno from ch_geno.collect()
-        file kinship from ch_kinship.collect()
-        tuple val(env), val(traitname), file(traitfile:"?/*") from ch_traitsplit
-
+        tuple val(env), val(traitname), path(traitfile, stageAs: '*.csv') from ch_traitsplit
     output:
-        tuple val(traitname), file('pheno.csv'), file('geno.pkl.xz'), file('kinship.pkl.xz') into ch_filtered
+        tuple val(env), val(traitname), path('pheno.csv'), path('geno.pkl.xz') into ch_filtered
 
     script:
         """
         #!/usr/bin/env python
 
+        import h5py
         import pandas as pd
         import numpy as np
 
-        pheno = pd.concat(map(lambda file: pd.read_csv(file, index_col=[0]), ['${traitfile.join("','")}']), axis=1, join='inner')
-        geno = pd.read_pickle('${geno}')
+        import logging
 
-        pheno_geno_intersect, strain_idx, pheno_idx = np.intersect1d(np.array(geno.columns), 
+        logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
+        logger = logging.getLogger()
+
+        pheno = pd.concat(map(lambda file: pd.read_csv(file, index_col=[0]), ['${traitfile.join("','")}']), axis=1, join='inner')
+
+        pheno.sort_index(axis=0, inplace=True)
+
+        # read SNP matrix
+        with h5py.File('${geno}', 'r') as genofile:
+            geno_acc_ids = genofile['accessions'][:].astype(np.int32)
+            snps = genofile['snps'][:].astype(np.int8)
+
+            chr_names = genofile['positions'].attrs.get('chrs')
+            chr_regions = np.array(genofile['positions'].attrs.get('chr_regions'))
+            geno_chroms = []
+            for i, reg in enumerate(chr_regions):
+                geno_chroms.extend(np.repeat(chr_names[i].decode('utf-8'), reg[1]-reg[0]))
+            pos = genofile['positions'][()].astype(np.int32)
+
+        geno_chroms = np.array(geno_chroms, dtype=np.int8)
+        pos = np.array(pos, dtype=np.int32)
+        
+        geno = pd.DataFrame(np.array(snps, dtype=np.int8),
+                            index=pd.MultiIndex.from_arrays([geno_chroms, pos]),
+                            columns=geno_acc_ids)
+
+        pheno_geno_intersect, strain_idx, pheno_idx = np.intersect1d(np.array(geno_acc_ids), 
                                                                      np.array(pheno.index),
                                                                      return_indices=True)
 
         accs_no_geno_info = np.array(pheno.index)[np.in1d(pheno.index, pheno_geno_intersect, invert=True)]
-        print("No genotype information for accessions: {}".format(accs_no_geno_info))
-
+        
         phenotypes = pheno.drop(accs_no_geno_info)
-
-        print("Removed them from list of phenotypes, leaving {} accessions.".format(len(phenotypes)))
-
         geno = geno.filter(items=pheno_geno_intersect, axis=1)
-        geno = geno[(geno.sum(axis=1) >= ${params.mac}) & (geno.sum(axis=1) <= geno.shape[1]-${params.mac})]
-        genotypes = geno.reindex(sorted(geno.columns), axis=1)
+        
+        logger.info('%i accessions with both genotype and phenotype. Removed %i accessions because of missing genotype: %s', len(phenotypes), len(accs_no_geno_info), accs_no_geno_info)
 
-        print("Removed {:d} snps because of MAC threshold ${params.mac}. (Remaining snps: {:d} across {:d} accessions)"
-        .format(geno.shape[0]-genotypes.shape[0], genotypes.shape[0], genotypes.shape[1]))
+        genotypes = geno[(geno.sum(axis=1) >= ${params.mac}) & (geno.sum(axis=1) <= geno.shape[1]-${params.mac})]
+
+        genotypes = genotypes.reindex(sorted(genotypes.columns), axis=1)
+
+        logger.info('Removed %i SNPs because of MAC threshold ${params.mac}. (Remaining SNPs: %i across %i accessions)', (geno.shape[0]-genotypes.shape[0]), genotypes.shape[0], genotypes.shape[1])
 
         phenotypes.to_csv("pheno.csv")
         genotypes.to_pickle("geno.pkl.xz")
-
-        geno_ids = np.array(genotypes.columns.astype(int))
-        kinship = pd.read_pickle('${kinship}')
-        kinship_filtered = kinship.loc[geno_ids,geno_ids]
-
-        kinship_filtered.to_pickle("kinship.pkl.xz")
         """
 }
 
+
 process runGWAS {
+    tag "$traitname"
+
+    validExitStatus 0,2
     publishDir "${params.outdir}/pvals", mode: 'copy'
     input:
-        tuple val(traitname), file(pheno), file(geno), file(kinship) from ch_filtered
+        tuple val(env), val(traitname), path(pheno), path(geno) from ch_filtered
 
     output:
-        tuple val(traitname), file('*.csv') into ch_pvals mode flatten
+        tuple val(env), val(traitname), path('*.csv') into ch_pvals mode flatten optional true
 
     script:
-        if (params.singletrait)
+        def transformation = params.transform == 'no_transformation' ? "" : ".apply(${params.transform}, raw=True)"
+        if (!params.multitrait)
             """
             #!/usr/bin/env python
-
+            
             import pandas as pd
             import numpy as np
             
             from limix.qtl import scan
-            from limix.qc import compute_maf
+            from limix.qc import compute_maf, normalise_covariance, mean_standardize, quantile_gaussianize, boxcox
+            from limix.stats import linear_kinship
 
-            phenotypes = pd.read_csv('${pheno}')
+            phenotypes = pd.read_csv('${pheno}', index_col=[0])${transformation}
 
             genotypes = pd.read_pickle('${geno}')
-            kinship = pd.read_pickle('${kinship}')
-
-            pheno_norm = phenotypes.values.astype(float)
-            p1 = pheno_norm[:, 0]
-            p1 = (p1 - p1.mean()) / p1.std()
-
-            # calculate maf and mac
-            mafs = compute_maf(genotypes.values.T)
-            macs = genotypes.sum(axis=1)
-
             chromosomes = np.array(genotypes.index.get_level_values(0))
             positions = np.array(genotypes.index.get_level_values(1))
 
+            geno = genotypes.to_numpy().T
+            kinship = linear_kinship(geno)
+            kinship_norm = normalise_covariance(kinship @ kinship.T)
+
+            pheno = phenotypes.to_numpy(dtype=np.float32)
+
+            if np.isnan(pheno).any():
+                print(f'Transformation of trait ${traitname} yielded NA values. Skipping analysis.')
+                exit(2)
+
+            # calculate maf and mac
+            mafs = compute_maf(geno)
+            macs = geno.sum(axis=0)
+
             freq = pd.DataFrame(data={'maf': np.array(mafs), 'mac': np.array(macs)},
-                                index=pd.MultiIndex.from_arrays([chromosomes, positions],
-                                names=['chrom','pos']))
+                                index=pd.MultiIndex.from_arrays([chromosomes, positions]))
 
-            result = scan(G=genotypes.values.T,
-                                    Y=p1,
-                                    K=kinship.values,
-                                    verbose=True)
+            st = scan(G=geno,
+                      Y=pheno,
+                      K=kinship_norm,
+                      verbose=True)
 
-            result = pd.DataFrame(result.stats['pv20'].values,
-                                index=pd.MultiIndex.from_arrays([chromosomes, positions]),
-                                names=['chrom','pos'],
-                                columns=['pv']).join(freq)
-            
-            result.to_csv("mac${params.mac}_${traitname}_singletrait.csv")
+            effsize = st.effsizes['h2'].loc[st.effsizes['h2']['effect_type'] == 'candidate']
+
+            def phenotypic_variance_explained(beta, beta_se, mafs, n):
+                '''Estimate phenotypic variance explained following Shim et al. (2015) https://doi.org/10.1371/journal.pone.0120758'''
+                return (2 * beta**2 * mafs * (1 - mafs)) / (2 * beta**2 * mafs * (1 - mafs) + beta_se**2 * 2 * n * mafs * (1 - mafs))
+
+            pve = phenotypic_variance_explained(effsize['effsize'].to_numpy(), effsize['effsize_se'].to_numpy(), mafs, pheno.shape[0])
+
+            result = pd.DataFrame(data={'pv': st.stats['pv20'].to_numpy(), 'gve': effsize['effsize'].to_numpy(), 'pve': np.array(pve)},
+                                  index=pd.MultiIndex.from_arrays([chromosomes, positions]))
+
+            if result['pv'].min() < ${params.pthresh}: 
+                #result['-log10pv'] = -np.log10(result['pv'])
+                result = result.join(freq)
+                result.to_csv("${env}_${traitname}_mac${params.mac}.csv", index_label=['chrom', 'pos'])
             """
         else
             """
@@ -158,79 +200,89 @@ process runGWAS {
             import numpy as np
             
             from limix.qtl import scan
-            from limix.qc import compute_maf
+            from limix.qc import compute_maf, normalise_covariance, mean_standardize, quantile_gaussianize, boxcox
+            from limix.stats import linear_kinship
 
-            phenotypes = pd.read_csv('${pheno}')
+            phenotypes = pd.read_csv('${pheno}', index_col=[0])${transformation}
 
             genotypes = pd.read_pickle('${geno}')
-            kinship = pd.read_pickle('${kinship}')
+            
+            geno = genotypes.to_numpy().T
 
-            pheno_norm = phenotypes.values.astype(float)
-            p1 = pheno_norm[:, 0]
-            p2 = pheno_norm[:, 1]
-            p1 = (p1 - p1.mean()) / p1.std()
-            p2 = (p2 - p2.mean()) / p2.std()
-            pheno_norm = np.vstack([p1, p2]).T
+            kinship = linear_kinship(geno)
+            kinship_norm = normalise_covariance(kinship @ kinship.T)
+            
+            pheno = phenotypes.to_numpy(dtype=np.float32)
 
-            n_pheno = pheno_norm.shape[1]  # number of traits
+            if np.isnan(pheno).any():
+                print(f'Transformation of trait ${traitname} yielded NA values. Skipping analysis.')
+                exit(2)
 
             # calculate maf and mac
-            mafs = compute_maf(genotypes.values.T)
-            macs = genotypes.sum(axis=1)
+            mafs = compute_maf(geno)
+            macs = geno.sum(axis=0)
 
             chromosomes = np.array(genotypes.index.get_level_values(0))
             positions = np.array(genotypes.index.get_level_values(1))
 
             freq = pd.DataFrame(data={'maf': np.array(mafs), 'mac': np.array(macs)},
-                                index=pd.MultiIndex.from_arrays([chromosomes, positions],
-                                names=['chrom','pos']))
+                                index=pd.MultiIndex.from_arrays([chromosomes, positions]))
+
+            n_pheno = pheno.shape[1]  # number of traits
 
             A = np.eye(n_pheno)  # p x p matrix of fixed effect sizes
             # common effects: 1 DoF
             Asnps0 = np.ones((n_pheno, 1))
             Asnps = np.eye(n_pheno)
 
-            print("Calculating mtlmm ... ")
-            mtlmm = scan(G=genotypes.values.T,
-                        Y=pheno_norm,
-                        K=kinship.values,
+            mtlmm = scan(G=geno,
+                        Y=pheno,
+                        K=kinship_norm,
                         A=A,
                         A0=Asnps0,
                         A1=Asnps,
                         verbose=True)
 
             # specific (GxE)
-            specific = pd.DataFrame(mtlmm.stats['pv21'].values,
-                                    index=pd.MultiIndex.from_arrays([chromosomes, positions],
-                                    names=['chrom','pos']),
-                                    columns=['pv']).join(freq)
+            specific = pd.DataFrame(mtlmm.stats['pv21'].to_numpy(),
+                                    index=pd.MultiIndex.from_arrays([chromosomes, positions]),
+                                    columns=['pv'])                      
+
             # common (G)
-            common = pd.DataFrame(mtlmm.stats['pv10'].values,
-                                index=pd.MultiIndex.from_arrays([chromosomes, positions],
-                                names=['chrom','pos']),
-                                columns=['pv']).join(freq)
+            common = pd.DataFrame(mtlmm.stats['pv10'].to_numpy(),
+                                  index=pd.MultiIndex.from_arrays([chromosomes, positions]),
+                                  columns=['pv'])
+
             # common (G + GxE)
-            any = pd.DataFrame(mtlmm.stats['pv20'].values,
-                            index=pd.MultiIndex.from_arrays([chromosomes, positions],
-                            names=['chrom','pos']),
-                            columns=['pv']).join(freq)
+            any = pd.DataFrame(mtlmm.stats['pv20'].to_numpy(),
+                               index=pd.MultiIndex.from_arrays([chromosomes, positions]),
+                               columns=['pv'])
 
             results =  {'specific': specific, 'common': common, 'any': any}
 
             for name, result in results.items():
-                result.to_csv("mac${params.mac}_${traitname}_{}.csv".format(name))
+                if result['pv'].min() < ${params.pthresh}:
+                    #result['-log10pv'] = -np.log10(result['pv'])
+                    result = result.join(freq)
+                    result.to_csv(f'${traitname}_mac${params.mac}_{name}.csv', index_label=['chrom', 'pos'])
             """
 }
 
 process plotGWAS {
-    publishDir "${params.outdir}/plots", mode: 'copy'
+    tag "$traitname"
+
+    publishDir "${params.outdir}/plots", mode: 'copy',
+        saveAs: { filename ->
+            if (filename.endsWith("manhattan.png")) "manhattan/$filename"
+            else if (filename.endsWith("qq.png")) "qq/$filename" }
     input:
-        tuple val(traitname), file(pvals) from ch_pvals
+        tuple val(env), val(traitname), path(pvals) from ch_pvals
 
     output:
-        tuple val(traitname), file('*manhattan.png'), file('*qq.png') into ch_plots
+        tuple val(env), val(traitname), path('*manhattan.png'), path('*qq.png') into ch_plots
 
     script:
+        def effect = params.multitrait ? env.join(' x ') + pvals.baseName.tokenize('_')[-1] : env
         """
         #!/usr/bin/env python
 
@@ -240,7 +292,7 @@ process plotGWAS {
 
         from limix.plot import manhattan, qqplot
 
-        def correct_multiple_tests(pvals, alpha=${params.alpha}):
+        def correct_multiple_tests(pvals, alpha=0.05):
             c = len(pvals)
             bonferroni = alpha/c 
             for idx, value in enumerate(sorted(pvals)):
@@ -253,7 +305,7 @@ process plotGWAS {
 
         bf, bh = correct_multiple_tests(result['pv'])
         plt.figure(figsize=[15, 4])
-        plt.title("${traitname} - ${pvals.baseName}")
+        plt.title("${effect}\\n${traitname}")
         manhattan(result,
                   colora='#AECF7B',
                   colorb='#09774D',
@@ -264,7 +316,7 @@ process plotGWAS {
         plt.legend(bbox_to_anchor=(0,1), loc='lower left', ncol=2)
         plt.savefig("${pvals.baseName}_manhattan.png")
         plt.figure(figsize=[15, 4])
-        plt.title("${traitname} - ${pvals.baseName}")
+        plt.title("${effect}\\n${traitname}")
         qqplot(result['pv'],
                band_kws=dict(color='#AECF7B',
                              alpha=0.5),

--- a/nextflow.config
+++ b/nextflow.config
@@ -6,12 +6,11 @@
  */
 
 params.outdir = "./results"
-params.genotype  = "/groups/becker/projects/becker_common/software/genotypes/1.0.0/1001genomes/all_chromosomes_binary.pkl.xz"
-params.kinship  = "/groups/becker/projects/becker_common/software/genotypes/1.0.0/1001genomes/kinship_ibs_binary_mac5.pkl.xz"
-params.phenotype = "/groups/becker/projects/becker_common/software/mtl/gwas-nf/test/*csv"
 params.mac = 5
-params.singletrait = false
-params.alpha = 0.05
+params.transform = "mean_standardize"
+params.multitrait = false
+params.pthresh = 0.05
+params.trait = false
 
 includeConfig 'conf/base.config'
 
@@ -29,12 +28,7 @@ manifest {
     name = 'GWAS-nf'
     version = '0.1'
     mainScript = 'main.nf'
-    nextflowVersion = '>=19.10.0'
-}
-
-tower {
-  accessToken = '381521ad7b481979918df52d245e904e31a42cb4'
-  enabled = true
+    nextflowVersion = '>=20.01.0'
 }
 
 timeline {
@@ -48,8 +42,4 @@ report {
 trace {
   enabled = true
   file = "${params.outdir}/execution_trace.txt"
-}
-dag {
-  enabled = true
-  file = "${params.outdir}/pipeline_dag.svg"
 }


### PR DESCRIPTION
this is a rather big one

* require SNP matrix as hdf5 file
* add option to transform the phenotype: --transform parameter,  supports zscore scaling, boxcox and quantile normalisation
* calculate phenotypic variance explained for single trait analyses
* add option to select traits when starting the pipeline: --trait parameter should be a comma-separated list of column names in input file
* explicitly pass dtype to pandas dataframe constructor. Saves huge amounts of memory
* singletrait is now the default mode. run multitrait analyses with --multitrait flag
* add option to only save the result if the minimum pvalue is below a certain threshold: --pthresh
* remove option to use prexisting kinship. kinship is now always calculated anew from SNP matrix filtered for accessions with a phenotype value
* removed --alpha parameter
* update config for cbe